### PR TITLE
Added new table that shows RA for swab samples.

### DIFF
--- a/scripts/prep-swab-validation.py
+++ b/scripts/prep-swab-validation.py
@@ -42,6 +42,7 @@ for delivery in target_deliveries:
             if row.get("demultiplexed") == "False":
                 continue
             metadata_samples[sample] = row
+
 genome_ids_to_exclude = [
     "MN369532.1",  # Vaccinia virus isolate, spurious hit
     "AY037928.1",  # Human endogenous retrovirus, spurious hit
@@ -78,17 +79,13 @@ for delivery in target_deliveries:
     sars_cov_2_reads = []
 
     past_observations = {}
-    if delivery == "NAO-ONT-20250328-Zephyr12b":
-        version = "v2.8.3.1"
-    else:
-        version = "v2.8.1.3-dev"
 
     subprocess.run(
         [
             "aws",
             "s3",
             "sync",
-            f"s3://nao-mgs-simon/{version}/{delivery}/output/results",
+            f"s3://nao-mgs-simon/v2.8.3.2{delivery}/output/results",
             f"deliveries/{delivery}/output/results",
         ]
     )

--- a/scripts/prep-swab-validation.py
+++ b/scripts/prep-swab-validation.py
@@ -24,6 +24,7 @@ target_deliveries = [
     "NAO-ONT-20250220-Zephyr11",
     "NAO-ONT-20250226-Zephyr10-QC2",
     "NAO-ONT-20250313-Zephyr12",
+    "NAO-ONT-20250328-Zephyr12b"
 ]
 
 HCOV_299E_TAXID = 11137
@@ -31,35 +32,73 @@ SARS_COV_2_TAXID = 2697049
 
 total_reads_to_validate = 0
 
-dashboard_dir = os.path.expanduser("~/code/mgs-restricted/dashboard")
-
-with open(os.path.join(dashboard_dir, "metadata_samples.json")) as f:
-    metadata_samples = json.load(f)
-
+metadata_samples = {}
+for delivery in target_deliveries:
+    with open(
+        os.path.join("..", "mgs-metadata", "deliveries", delivery, "metadata.tsv")
+    ) as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        for row in reader:
+            sample = row["sample"]
+            if row.get("demultiplexed") == "False":
+                continue
+            metadata_samples[sample] = row
 genome_ids_to_exclude = [
     "MN369532.1",  # Vaccinia virus isolate, spurious hit
     "AY037928.1",  # Human endogenous retrovirus, spurious hit
     "KY766069.1",  # Zika virus isolate
 ]
 
+WIGGLE_ROOM=3 # count dups even if start/end is off by this many bp
+
+past_observations = {}
+
+def check_dup(date, fine_location, genome_id, minimap2_ref_start, minimap2_ref_end):
+    key = (date, fine_location, genome_id)
+    if key not in past_observations:
+        past_observations[key] = []
+
+    is_duplicate = False
+
+    for existing_start, existing_end in past_observations[key]:
+        if (abs(existing_start - minimap2_ref_start) <= WIGGLE_ROOM and
+            abs(existing_end - minimap2_ref_end) <= WIGGLE_ROOM):
+            is_duplicate = True
+
+    past_observations[key].append((minimap2_ref_start, minimap2_ref_end))
+    return is_duplicate
+
+sample_reads = defaultdict(int)
+
 for delivery in target_deliveries:
-    print(delivery)
     taxid_counts = Counter()
     to_validate = []
     # One sample has a ~7000 HCOV-299E reads, which makes BLAST choke.
     hcov_299E_reads = []
     # We don't add SARS-CoV-2 to the validation set because BLAST chokes on SARS-CoV-2 reads.
     sars_cov_2_reads = []
+
+    past_observations = {}
+    if delivery == "NAO-ONT-20250328-Zephyr12b":
+        version = "v2.8.3.1"
+    else:
+        version = "v2.8.1.3-dev"
+
     subprocess.run(
         [
             "aws",
             "s3",
             "sync",
-            f"s3://nao-mgs-simon/v2.8.1.3-dev/{delivery}/output/results",
+            f"s3://nao-mgs-simon/{version}/{delivery}/output/results",
             f"deliveries/{delivery}/output/results",
         ]
     )
     os.makedirs(f"delivery_analyses/{delivery}", exist_ok=True)
+
+    with gzip.open(f"deliveries/{delivery}/output/results/read_counts.tsv.gz", "rt") as inf:
+        for row in csv.DictReader(inf, delimiter="\t"):
+            sample_id = row["sample"]
+            sample_reads[sample_id] += int(row["n_reads_single"])
 
     with gzip.open(f"deliveries/{delivery}/output/results/hv.tsv.gz", "rt") as inf:
         for row in csv.DictReader(inf, delimiter="\t"):
@@ -71,7 +110,7 @@ for delivery in target_deliveries:
 
             read_id = row["query_name"]
 
-            sample_id = row["sample"].split("-div")[0]
+            sample_id = row["sample"]
             sample_metadata = metadata_samples[sample_id]
             date = sample_metadata["date"]
             fine_location = sample_metadata["fine_location"]
@@ -79,7 +118,11 @@ for delivery in target_deliveries:
             query_seq = row["query_seq_clean"]
             query_qual = row["query_qual_clean"]
 
+            minimap2_ref_start = int(row["minimap2_ref_start"])
+            minimap2_ref_end = int(row["minimap2_ref_end"])
+
             if delivery == "NAO-ONT-20250220-Zephyr11" and taxid == HCOV_299E_TAXID:
+                is_duplicate = check_dup(date, fine_location, genome_id, minimap2_ref_start, minimap2_ref_end)
                 hcov_299E_reads.append(
                     (
                         taxid,
@@ -89,9 +132,12 @@ for delivery in target_deliveries:
                         fine_location,
                         read_id,
                         sample_id,
+                        is_duplicate,
                     )
                 )
+
             elif taxid == SARS_COV_2_TAXID:
+                is_duplicate = check_dup(date, fine_location, genome_id, minimap2_ref_start, minimap2_ref_end)
                 sars_cov_2_reads.append(
                     (
                         taxid,
@@ -101,6 +147,7 @@ for delivery in target_deliveries:
                         fine_location,
                         read_id,
                         sample_id,
+                        is_duplicate,
                     )
                 )
             else:
@@ -139,22 +186,29 @@ for delivery in target_deliveries:
             f"delivery_analyses/{delivery}/non_validated.tsv.gz", "wt"
         ) as outf:
             outf.write(
-                        "\t".join(("taxid", "sequence", "quality", "date", "loc", "read_id", "sample_id"))
+                        "\t".join(("taxid", "sequence", "quality", "date", "loc", "read_id", "sample_id", "is_duplicate"))
                         + "\n"
                     )
-            for taxid, seq, qual, date, loc, read_id, sample_id in hcov_299E_reads:
+            for taxid, seq, qual, date, loc, read_id, sample_id, is_duplicate in hcov_299E_reads:
                 outf.write(
-                    "\t".join((str(taxid), seq, qual, date, loc, read_id, sample_id))
+                    "\t".join((str(taxid), seq, qual, date, loc, read_id, sample_id, str(is_duplicate)))
                     + "\n"
                 )
 
-            for taxid, seq, qual, date, loc, read_id, sample_id in sars_cov_2_reads:
+            for taxid, seq, qual, date, loc, read_id, sample_id, is_duplicate in sars_cov_2_reads:
                 outf.write(
-                    "\t".join((str(taxid), seq, qual, date, loc, read_id, sample_id))
+                    "\t".join((str(taxid), seq, qual, date, loc, read_id, sample_id, str(is_duplicate)))
                     + "\n"
                 )
+
 
     for count, taxid in sorted((c, t) for (t, c) in taxid_counts.items()):
         print(count, taxid, taxid_names[taxid])
 
 print(f"Total reads to validate: {total_reads_to_validate}")
+
+with open("n_reads_per_swab_sample.tsv", "wt") as outf:
+    writer = csv.writer(outf, delimiter="\t")
+    writer.writerow(["sample", "reads"])
+    for sample, reads in sorted(sample_reads.items()):
+        writer.writerow([sample, reads])

--- a/scripts/prep-swab-validation.py
+++ b/scripts/prep-swab-validation.py
@@ -9,8 +9,7 @@ from collections import defaultdict, Counter
 from datetime import datetime
 from dateutil import parser
 import sys
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from scripts.taxonomy import load_taxonomy_names, load_human_infecting_taxids, load_taxonomy_tree
+from taxonomy import load_taxonomy_names, load_human_infecting_taxids, load_taxonomy_tree
 
 parents, children = load_taxonomy_tree()
 taxid_names = load_taxonomy_names()

--- a/scripts/prep-ww-validation.py
+++ b/scripts/prep-ww-validation.py
@@ -65,7 +65,7 @@ def descends_from_target(taxid, cache={}):
     return cache[taxid]
 
 
-
+sample_reads = defaultdict(int)
 
 # We don't add SARS-CoV-2 to the validation set because BLAST is disproprtionately slow on SARS-CoV-2 reads (as there are so many reference genomes for SARS-CoV-2)
 
@@ -83,6 +83,13 @@ for delivery in target_deliveries:
             f"deliveries/{delivery}/output/results",
         ]
     )
+
+
+    with gzip.open(f"deliveries/{delivery}/output/results/read_counts.tsv.gz", "rt") as inf:
+        for row in csv.DictReader(inf, delimiter="\t"):
+            sample_id = row["sample"]
+            sample_reads[sample_id] += int(row["n_read_pairs"])
+
     os.makedirs(f"delivery_analyses/{delivery}", exist_ok=True)
     with gzip.open(
         f"deliveries/{delivery}/output/results/virus_hits_filtered.tsv.gz", "rt"
@@ -168,3 +175,10 @@ for delivery in target_deliveries:
 
     for count, taxid in sorted((c, t) for (t, c) in taxid_counts.items()):
         print(count, taxid, taxid_names[taxid])
+
+
+with open("n_reads_per_ww_sample.tsv", "wt") as outf:
+    writer = csv.writer(outf, delimiter="\t")
+    writer.writerow(["sample", "reads"])
+    for sample, reads in sorted(sample_reads.items()):
+        writer.writerow([sample, reads])

--- a/scripts/swab-ra-table.py
+++ b/scripts/swab-ra-table.py
@@ -39,8 +39,8 @@ with open(os.path.join("outputs", "n_reads_per_swab_sample.tsv")) as f:
 
 
 # Create per-category counts and get treatment for each sample
-date_loc_read_counts = defaultdict(int)
-treatment_read_counts = defaultdict(int)
+date_loc_read_counts = Counter()
+treatment_read_counts = Counter()
 sample_treatment = {}
 
 for delivery in target_deliveries:
@@ -147,7 +147,7 @@ for (date, location, pathogen), counts in samples.items():
     samples[(date, location, pathogen)]["all_reads"] = n_reads
 
 for (date, location, pathogen, treatment), counts in treatment_samples.items():
-    
+
     n_reads = treatment_read_counts[treatment]
     treatment_samples[(date, location, pathogen, treatment)]["all_reads"] = n_reads
 

--- a/scripts/swab-ra-table.py
+++ b/scripts/swab-ra-table.py
@@ -4,13 +4,9 @@ import csv
 import json
 import os
 import sys
-from collections import defaultdict
+from collections import defaultdict, Counter
 from datetime import datetime
-
-# Add local module path
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-# Local imports
-from scripts.taxonomy import load_taxonomy_names
+from taxonomy import load_taxonomy_names
 
 # Constants and paths
 dashboard_dir = os.path.expanduser("~/code/mgs-restricted/dashboard")
@@ -24,9 +20,6 @@ def is_date_in_range(date):
 
 # Load data
 taxid_names = load_taxonomy_names()
-
-with open(os.path.join(dashboard_dir, "metadata_samples.json")) as f:
-    metadata_samples = json.load(f)
 
 read_counts = {}
 with open("n_reads_per_swab_sample.tsv") as f:
@@ -65,7 +58,7 @@ first_level_mapping = {
 
 
 # Initialize data structures
-samples = defaultdict(lambda: defaultdict(int))  # (date, location, pathogen) -> counts
+samples = defaultdict(Counter)  # (date, location, pathogen) -> counts
 date_loc_sample_map = defaultdict(set)  # (date, location) -> set of samples
 
 # Process classified reads

--- a/scripts/swab-ra-table.py
+++ b/scripts/swab-ra-table.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# Standard library imports
+import csv
+import json
+import os
+import sys
+from collections import defaultdict
+from datetime import datetime
+
+# Add local module path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Local imports
+from scripts.taxonomy import load_taxonomy_names
+
+# Constants and paths
+dashboard_dir = os.path.expanduser("~/code/mgs-restricted/dashboard")
+validation_output_dir = "validation-output"
+START_DATE = datetime(2025, 1, 7)
+END_DATE = datetime(2025, 2, 25)
+
+# Functions
+def is_date_in_range(date):
+    return START_DATE <= date <= END_DATE
+
+# Load data
+taxid_names = load_taxonomy_names()
+
+with open(os.path.join(dashboard_dir, "metadata_samples.json")) as f:
+    metadata_samples = json.load(f)
+
+read_counts = {}
+with open("n_reads_per_swab_sample.tsv") as f:
+    for row in csv.DictReader(f, delimiter="\t"):
+        read_counts[row["sample"]] = int(row["reads"])
+
+
+# Create virus clade groupings
+first_level_mapping = {
+    # Coronaviruses (seasonal)
+    "Human coronavirus OC43": "HCoV-OC43",
+    "Human coronavirus 229E": "HCoV-229E",
+    "Human coronavirus HKU1": "HCoV-HKU1",
+    "Human coronavirus NL63": "HCoV-NL63",
+
+    # Coronaviruses (SARS-CoV-2)
+    "Severe acute respiratory syndrome coronavirus 2": "SARS-CoV-2",
+
+    # Influenza
+    "H1N1": "Influenza A",
+
+    # Rhinoviruses
+    "Rhinovirus A34": "Rhinovirus A",
+    "Rhinovirus A94": "Rhinovirus A",
+    "Rhinovirus B37": "Rhinovirus B",
+    "Rhinovirus C2": "Rhinovirus C",
+    "Rhinovirus C36": "Rhinovirus C",
+    "Rhinovirus C42": "Rhinovirus C",
+    "Rhinovirus C56": "Rhinovirus C",
+
+    # Mononegavirales
+    "RSVA": "RSV-A",
+    "RSVB": "RSV-B",
+    "HPIV4": "HPIV4b"
+}
+
+
+# Initialize data structures
+samples = defaultdict(lambda: defaultdict(int))  # (date, location, pathogen) -> counts
+date_loc_sample_map = defaultdict(set)  # (date, location) -> set of samples
+
+# Process classified reads
+with open(os.path.join(validation_output_dir, "swabs-classified-all-reads.tsv")) as f:
+    for row in csv.DictReader(f, delimiter="\t"):
+        date = datetime.strptime(row["date"], "%Y-%m-%d")
+        if not is_date_in_range(date):
+            continue
+
+        duplicate = row["is_duplicate"]
+        location = row["loc"]
+        pathogen = row["genome_name"]
+        sample = row["sample"]
+
+        date_loc_sample_map[(date, location)].add(sample)
+        if duplicate == "True":
+            samples[(date, location, pathogen)]["non_dedup"] += 1
+        else:
+            samples[(date, location, pathogen)]["dedup"] += 1
+            samples[(date, location, pathogen)]["non_dedup"] += 1
+
+
+# Process non-validated reads
+with open(os.path.join(validation_output_dir, "swabs-non-validated-reads.tsv")) as f:
+    for row in csv.DictReader(f, delimiter="\t"):
+        date = datetime.strptime(row["date"], "%Y-%m-%d")
+        if not is_date_in_range(date):
+            continue
+
+        duplicate = row["is_duplicate"]
+        location = row["loc"]
+        taxid = row["taxid"]
+        sample = row["sample_id"]
+        pathogen = taxid_names[int(taxid)]
+
+        date_loc_sample_map[(date, location)].add(sample)
+        if duplicate == "True":
+            samples[(date, location, pathogen)]["non_dedup"] += 1
+        else:
+            samples[(date, location, pathogen)]["dedup"] += 1
+            samples[(date, location, pathogen)]["non_dedup"] += 1
+
+# Calculate total reads
+for (date, location, pathogen), counts in samples.items():
+    n_reads = 0
+    for sample in date_loc_sample_map[(date, location)]:
+        n_reads += read_counts[sample]
+    samples[(date, location, pathogen)]["all_reads"] = n_reads
+
+# Output results
+with open("swabs-ra-summary.tsv", "w") as outf:
+    writer = csv.writer(outf, delimiter="\t")
+    writer.writerow(["date", "location", "species", "assignment", "non_dedup_hv", "dedup_hv", "all_reads"])
+    # Sort samples by date
+    sorted_samples = sorted(samples.items(), key=lambda x: x[0][0])
+    for (date, location, pathogen), data in sorted_samples:
+        species = first_level_mapping[pathogen]
+        date_str = date.strftime("%y%m%d")
+        writer.writerow([
+            date_str,
+            location,
+            species,
+            pathogen,
+            data.get("non_dedup", 0),
+            data.get("dedup", 0),
+            data["all_reads"],
+        ])

--- a/scripts/swab-ra-table.py
+++ b/scripts/swab-ra-table.py
@@ -9,22 +9,56 @@ from datetime import datetime
 from taxonomy import load_taxonomy_names
 
 # Constants and paths
-dashboard_dir = os.path.expanduser("~/code/mgs-restricted/dashboard")
 validation_output_dir = "validation-output"
 START_DATE = datetime(2025, 1, 7)
 END_DATE = datetime(2025, 2, 25)
+
+target_deliveries = [
+    "NAO-ONT-20250120-Zephyr8",
+    "NAO-ONT-20250127-Zephyr9",
+    "NAO-ONT-20250213-Zephyr10",
+    "NAO-ONT-20250213-Zephyr10-QC",
+    "NAO-ONT-20250220-Zephyr11",
+    "NAO-ONT-20250226-Zephyr10-QC2",
+    "NAO-ONT-20250313-Zephyr12",
+    "NAO-ONT-20250328-Zephyr12b"
+]
 
 # Functions
 def is_date_in_range(date):
     return START_DATE <= date <= END_DATE
 
-# Load data
+# Load names
 taxid_names = load_taxonomy_names()
 
+# Load counts
 read_counts = {}
-with open("n_reads_per_swab_sample.tsv") as f:
+with open(os.path.join("outputs", "n_reads_per_swab_sample.tsv")) as f:
     for row in csv.DictReader(f, delimiter="\t"):
         read_counts[row["sample"]] = int(row["reads"])
+
+
+# Create per-category counts and get treatment for each sample
+date_loc_read_counts = defaultdict(int)
+treatment_read_counts = defaultdict(int)
+sample_treatment = {}
+
+for delivery in target_deliveries:
+    with open(
+        os.path.join("..", "mgs-metadata", "deliveries", delivery, "metadata.tsv")
+    ) as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        for row in reader:
+            sample = row["sample"]
+            if row.get("demultiplexed") == "False":
+                continue
+            date = datetime.strptime(row["date"], "%Y-%m-%d")
+            location = row["fine_location"]
+            treatment = row["notes"]
+            date_loc_read_counts[(date, location)] += read_counts.get(sample, 0)
+            sample_treatment[sample] = treatment
+            treatment_read_counts[treatment] += read_counts.get(sample, 0)
+
 
 
 # Create virus clade groupings
@@ -59,7 +93,7 @@ first_level_mapping = {
 
 # Initialize data structures
 samples = defaultdict(Counter)  # (date, location, pathogen) -> counts
-date_loc_sample_map = defaultdict(set)  # (date, location) -> set of samples
+treatment_samples = defaultdict(Counter) # (date, location, pathogen, treatment) -> counts
 
 # Process classified reads
 with open(os.path.join(validation_output_dir, "swabs-classified-all-reads.tsv")) as f:
@@ -72,14 +106,15 @@ with open(os.path.join(validation_output_dir, "swabs-classified-all-reads.tsv"))
         location = row["loc"]
         pathogen = row["genome_name"]
         sample = row["sample"]
-
-        date_loc_sample_map[(date, location)].add(sample)
+        treatment = sample_treatment[sample]
         if duplicate == "True":
             samples[(date, location, pathogen)]["non_dedup"] += 1
+            treatment_samples[(date, location, pathogen, treatment)]["non_dedup"] += 1
         else:
             samples[(date, location, pathogen)]["dedup"] += 1
             samples[(date, location, pathogen)]["non_dedup"] += 1
-
+            treatment_samples[(date, location, pathogen, treatment)]["non_dedup"] += 1
+            treatment_samples[(date, location, pathogen, treatment)]["dedup"] += 1
 
 # Process non-validated reads
 with open(os.path.join(validation_output_dir, "swabs-non-validated-reads.tsv")) as f:
@@ -93,20 +128,28 @@ with open(os.path.join(validation_output_dir, "swabs-non-validated-reads.tsv")) 
         taxid = row["taxid"]
         sample = row["sample_id"]
         pathogen = taxid_names[int(taxid)]
+        treatment = sample_treatment[sample]
 
-        date_loc_sample_map[(date, location)].add(sample)
         if duplicate == "True":
             samples[(date, location, pathogen)]["non_dedup"] += 1
+            treatment_samples[(date, location, pathogen, treatment)]["non_dedup"] += 1
         else:
             samples[(date, location, pathogen)]["dedup"] += 1
             samples[(date, location, pathogen)]["non_dedup"] += 1
+            treatment_samples[(date, location, pathogen, treatment)]["non_dedup"] += 1
+            treatment_samples[(date, location, pathogen, treatment)]["dedup"] += 1
 
-# Calculate total reads
+
+
+# Get reads for each grouping category
 for (date, location, pathogen), counts in samples.items():
-    n_reads = 0
-    for sample in date_loc_sample_map[(date, location)]:
-        n_reads += read_counts[sample]
+    n_reads = date_loc_read_counts[(date, location)]
     samples[(date, location, pathogen)]["all_reads"] = n_reads
+
+for (date, location, pathogen, treatment), counts in treatment_samples.items():
+    
+    n_reads = treatment_read_counts[treatment]
+    treatment_samples[(date, location, pathogen, treatment)]["all_reads"] = n_reads
 
 # Output results
 with open("swabs-ra-summary.tsv", "w") as outf:
@@ -126,3 +169,11 @@ with open("swabs-ra-summary.tsv", "w") as outf:
             data.get("dedup", 0),
             data["all_reads"],
         ])
+
+with open("swabs-ra-per-treatment-summary.tsv", "w") as outf:
+    writer = csv.writer(outf, delimiter="\t")
+    writer.writerow(["date", "location", "species", "pathogen", "treatment", "non_dedup", "dedup", "all_reads"])
+    for (date, location, pathogen, treatment), data in sorted(treatment_samples.items()):
+        species = first_level_mapping[pathogen]
+        date_str = date.strftime("%y%m%d")
+        writer.writerow([date_str, location, species, pathogen, treatment, data.get("non_dedup", 0), data.get("dedup", 0), data["all_reads"]])


### PR DESCRIPTION
To support the table and the addition of Zephyr12b, I did the following:
 - As I'm now at Zephyr12b, I need to switch metadata parsing from mgs-restricted to mgs-metadata.
    - Added parsing of read_counts.tsv.gz.
 - Support identifying duplicates in non-BLASTed swab reads (e.g., SARS-CoV-2) using minimap2 alignments.

@jeffkaufman Let me know if I should factor out the read count parsing, currently that's tacked onto `prep-*-validation.py`, which isn't very clean.