### PR TITLE
Swab counts table + metadata_utils.py

### DIFF
--- a/scripts/metadata_utils.py
+++ b/scripts/metadata_utils.py
@@ -160,6 +160,7 @@ def pathogens_to_ignore():
         "Enterovirus C99",
         "Enterovirus D68",
         "Human mastadenovirus A",
+        "Human mastadenovirus F",
         "Human mastadenovirus B114",
         "Poliovirus 2",
         "Human adenovirus 5",

--- a/scripts/metadata_utils.py
+++ b/scripts/metadata_utils.py
@@ -140,7 +140,7 @@ def second_level_mapping(assignment):
 
 
 def pathogens_to_ignore():
-    # We're restricting our analysis to respiratory pathogens
+    # We're restricting our analysis to respiratory pathogens and non-DNA respiratory pathogens (DNA pathogens are unlikely to be found due to a DNAse step in swab processing protocol)
     return [
         "Apodemus agrarius picornavirus strain Longwan-Rn37 polyprotein",
         "Coxsackievirus A1",

--- a/scripts/metadata_utils.py
+++ b/scripts/metadata_utils.py
@@ -1,0 +1,167 @@
+from datetime import datetime
+
+def is_date_in_range(date):
+    return datetime(2025, 1, 3) <= date <= datetime(2025, 2, 15)
+
+def first_level_mapping(assignment):
+    mapping = {
+        # Coronaviruses (seasonal)
+        "Human coronavirus OC43": "HCoV-OC43",
+        "Human coronavirus 229E": "HCoV-229E",
+        "Human coronavirus HKU1": "HCoV-HKU1",
+        "Human coronavirus NL63": "HCoV-NL63",
+
+        # Coronaviruses (SARS-CoV-2)
+        "Severe acute respiratory syndrome coronavirus 2": "SARS-CoV-2",
+
+        # Enteroviruses
+        "Coxsackievirus A22": "Coxsackievirus A",
+        "Coxsackievirus A24": "Coxsackievirus A",
+        "Coxsackievirus A19": "Coxsackievirus A",
+        "Coxsackievirus A9": "Coxsackievirus A",
+        "Coxsackievirus A6": "Coxsackievirus A",
+        "Coxsackievirus A4": "Coxsackievirus A",
+        "Coxsackievirus A1": "Coxsackievirus A",
+        "Enterovirus A": "Enterovirus A",
+        "Enterovirus A71": "Enterovirus A",
+        "Enterovirus A76": "Enterovirus A",
+        "Enterovirus B": "Enterovirus B",
+        "Enterovirus C116": "Enterovirus C",
+        "Enterovirus C113": "Enterovirus C",
+        "Enterovirus C99": "Enterovirus C",
+        "Enterovirus D68": "Enterovirus D",
+        "Echovirus E11": "Echovirus E",
+        "Human enterovirus isolate EV/Human/CMRHP58/CMR/2014": "Human enterovirus",
+        "Poliovirus 2": "Poliovirus",
+
+        # Rhinoviruses
+        "Rhinovirus A": "Rhinovirus A",
+        "Rhinovirus A1": "Rhinovirus A",
+        "Rhinovirus A12": "Rhinovirus A",
+        "Rhinovirus A24": "Rhinovirus A",
+        "Rhinovirus A34": "Rhinovirus A",
+        "Rhinovirus A40": "Rhinovirus A",
+        "Rhinovirus A54": "Rhinovirus A",
+        "Rhinovirus A80": "Rhinovirus A",
+        "Rhinovirus A94": "Rhinovirus A",
+        "Rhinovirus B3": "Rhinovirus B",
+        "Rhinovirus B37": "Rhinovirus B",
+        "Rhinovirus B103": "Rhinovirus B",
+        "Rhinovirus C": "Rhinovirus C",
+        "Rhinovirus C1": "Rhinovirus C",
+        "Rhinovirus C2": "Rhinovirus C",
+        "Rhinovirus C3": "Rhinovirus C",
+        "Rhinovirus C4": "Rhinovirus C",
+        "Rhinovirus C7": "Rhinovirus C",
+        "Rhinovirus C8": "Rhinovirus C",
+        "Rhinovirus C11": "Rhinovirus C",
+        "Rhinovirus C19": "Rhinovirus C",
+        "Rhinovirus C20": "Rhinovirus C",
+        "Rhinovirus C34": "Rhinovirus C",
+        "Rhinovirus C36": "Rhinovirus C",
+        "Rhinovirus C42": "Rhinovirus C",
+        "Rhinovirus C44": "Rhinovirus C",
+        "Rhinovirus C55": "Rhinovirus C",
+        "Rhinovirus C56": "Rhinovirus C",
+
+        # Mononegavirales
+        "RSV-A": "RSV-A",
+        "RSV-B": "RSV-B",
+        "RSVA": "RSV-A",
+        "RSVB": "RSV-B",
+        "HMPV-1": "HMPV-1",
+        "HPIV1": "HPIV1",
+        "HPIV2": "HPIV2",
+        "HPIV4b": "HPIV4",
+        "HPIV4": "HPIV4",
+        # Influenza
+        "H3N2": "H3N2",
+        "H1N1": "H1N1",
+        "Flu B": "Flu B",
+
+        # Adenoviruses
+        "Human mastadenovirus A": "Human mastadenovirus A",
+        "Human mastadenovirus B114": "Human mastadenovirus B114",
+        "Human adenovirus 5": "Human adenovirus 5",
+
+        # Other
+        "Apodemus agrarius picornavirus strain Longwan-Rn37 polyprotein": "Apodemus agrarius picornavirus"
+    }
+    return mapping[assignment]
+
+def second_level_mapping(assignment):
+    mapping = {
+        # Coronaviruses (seasonal)
+        "HCoV-OC43": "Coronaviruses (seasonal)",
+        "HCoV-229E": "Coronaviruses (seasonal)",
+        "HCoV-HKU1": "Coronaviruses (seasonal)",
+        "HCoV-NL63": "Coronaviruses (seasonal)",
+
+        # Coronaviruses (SARS-CoV-2)
+        "SARS-CoV-2": "Coronaviruses (SARS-CoV-2)",
+
+        # Enteroviruses
+        "Coxsackievirus A": "Enteroviruses",
+        "Enterovirus A": "Enteroviruses",
+        "Enterovirus B": "Enteroviruses",
+        "Enterovirus C": "Enteroviruses",
+        "Enterovirus D": "Enteroviruses",
+        "Echovirus E": "Enteroviruses",
+        "Human enterovirus": "Enteroviruses",
+        "Poliovirus": "Enteroviruses",
+
+        # Rhinoviruses
+        "Rhinovirus A": "Rhinoviruses",
+        "Rhinovirus B": "Rhinoviruses",
+        "Rhinovirus C": "Rhinoviruses",
+
+        # Mononegavirales
+        "RSV-A": "Mononegavirales",
+        "RSV-B": "Mononegavirales",
+        "HMPV-1": "Mononegavirales",
+        "HPIV1": "Mononegavirales",
+        "HPIV2": "Mononegavirales",
+        "HPIV4": "Mononegavirales",
+
+        # Influenza
+        "H3N2": "Influenza",
+        "H1N1": "Influenza",
+        "Flu B": "Influenza",
+
+        # Adenoviruses
+        "Human mastadenovirus A": "Adenoviruses",
+        "Human mastadenovirus B114": "Adenoviruses",
+        "Human adenovirus 5": "Adenoviruses",
+
+        # Other
+        "Apodemus agrarius picornavirus": "Other"
+    }
+    return mapping[assignment]
+
+
+def pathogens_to_ignore():
+    # We're restricting our analysis to respiratory pathogens
+    return [
+        "Apodemus agrarius picornavirus strain Longwan-Rn37 polyprotein",
+        "Coxsackievirus A1",
+        "Coxsackievirus A19",
+        "Coxsackievirus A22",
+        "Coxsackievirus A24",
+        "Coxsackievirus A4",
+        "Coxsackievirus A6",
+        "Coxsackievirus A9",
+        "Echovirus E11",
+        "Enterovirus A",
+        "Enterovirus A71",
+        "Enterovirus A76",
+        "Enterovirus B",
+        "Enterovirus C113",
+        "Enterovirus C116",
+        "Enterovirus C99",
+        "Enterovirus D68",
+        "Human mastadenovirus A",
+        "Human mastadenovirus B114",
+        "Poliovirus 2",
+        "Human adenovirus 5",
+        "Human enterovirus isolate EV/Human/CMRHP58/CMR/2014",
+    ]

--- a/scripts/metadata_utils.py
+++ b/scripts/metadata_utils.py
@@ -140,7 +140,7 @@ def second_level_mapping(assignment):
 
 
 def pathogens_to_ignore():
-    # We're restricting our analysis to respiratory pathogens and non-DNA respiratory pathogens (DNA pathogens are unlikely to be found due to a DNAse step in swab processing protocol)
+    # We're restricting our analysis to RNA respiratory pathogens. Our goal is to make a comparison between wastewater and swabs, and our swab protocol includes a DNase step.
     return [
         "Apodemus agrarius picornavirus strain Longwan-Rn37 polyprotein",
         "Coxsackievirus A1",

--- a/scripts/swab-ra-tables.py
+++ b/scripts/swab-ra-tables.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
 # Standard library imports
 import csv
-import json
 import os
-import sys
 from collections import defaultdict, Counter
 from datetime import datetime
 from taxonomy import load_taxonomy_names
 
+from metadata_utils import first_level_mapping, second_level_mapping, is_date_in_range
+
 # Constants and paths
 validation_output_dir = "validation-output"
-START_DATE = datetime(2025, 1, 7)
-END_DATE = datetime(2025, 2, 25)
+tables_dir = "tables"
+os.makedirs(tables_dir, exist_ok=True)
 
 target_deliveries = [
     "NAO-ONT-20250120-Zephyr8",
@@ -24,21 +24,19 @@ target_deliveries = [
     "NAO-ONT-20250328-Zephyr12b"
 ]
 
-# Functions
-def is_date_in_range(date):
-    return START_DATE <= date <= END_DATE
 
-# Load names
+# ---------------------------------------------------------------------
+# Look‑ups
+# ---------------------------------------------------------------------
+
 taxid_names = load_taxonomy_names()
 
-# Load counts
 read_counts = {}
 with open(os.path.join("outputs", "n_reads_per_swab_sample.tsv")) as f:
     for row in csv.DictReader(f, delimiter="\t"):
         read_counts[row["sample"]] = int(row["reads"])
 
 
-# Create per-category counts and get treatment for each sample
 date_loc_read_counts = Counter()
 treatment_read_counts = Counter()
 sample_treatment = {}
@@ -52,44 +50,18 @@ for delivery in target_deliveries:
             sample = row["sample"]
             if row.get("demultiplexed") == "False":
                 continue
+
             date = datetime.strptime(row["date"], "%Y-%m-%d")
             location = row["fine_location"]
             treatment = row["notes"]
-            date_loc_read_counts[(date, location)] += read_counts.get(sample, 0)
             sample_treatment[sample] = treatment
-            treatment_read_counts[treatment] += read_counts.get(sample, 0)
+            n_reads = read_counts.get(sample, 0)
+            date_loc_read_counts[(date, location)]              += n_reads
+            treatment_read_counts[(date, location, treatment)]  += n_reads
 
-
-
-# Create virus clade groupings
-first_level_mapping = {
-    # Coronaviruses (seasonal)
-    "Human coronavirus OC43": "HCoV-OC43",
-    "Human coronavirus 229E": "HCoV-229E",
-    "Human coronavirus HKU1": "HCoV-HKU1",
-    "Human coronavirus NL63": "HCoV-NL63",
-
-    # Coronaviruses (SARS-CoV-2)
-    "Severe acute respiratory syndrome coronavirus 2": "SARS-CoV-2",
-
-    # Influenza
-    "H1N1": "Influenza A",
-
-    # Rhinoviruses
-    "Rhinovirus A34": "Rhinovirus A",
-    "Rhinovirus A94": "Rhinovirus A",
-    "Rhinovirus B37": "Rhinovirus B",
-    "Rhinovirus C2": "Rhinovirus C",
-    "Rhinovirus C36": "Rhinovirus C",
-    "Rhinovirus C42": "Rhinovirus C",
-    "Rhinovirus C56": "Rhinovirus C",
-
-    # Mononegavirales
-    "RSVA": "RSV-A",
-    "RSVB": "RSV-B",
-    "HPIV4": "HPIV4b"
-}
-
+# ---------------------------------------------------------------------
+# Counting HV reads (deduplicated and non-deduplicated)
+# ---------------------------------------------------------------------
 
 # Initialize data structures
 samples = defaultdict(Counter)  # (date, location, pathogen) -> counts
@@ -141,30 +113,50 @@ with open(os.path.join(validation_output_dir, "swabs-non-validated-reads.tsv")) 
 
 
 
-# Get reads for each grouping category
+# ---------------------------------------------------------------------
+# Getting total reads
+# ---------------------------------------------------------------------
+
+# Get total reads for each grouping category
 for (date, location, pathogen), counts in samples.items():
     n_reads = date_loc_read_counts[(date, location)]
     samples[(date, location, pathogen)]["all_reads"] = n_reads
 
 for (date, location, pathogen, treatment), counts in treatment_samples.items():
 
-    n_reads = treatment_read_counts[treatment]
+    n_reads = treatment_read_counts[(date, location, treatment)]
     treatment_samples[(date, location, pathogen, treatment)]["all_reads"] = n_reads
+
+
+# ---------------------------------------------------------------------
+# Output results
+# ---------------------------------------------------------------------
 
 # Output results
 with open(os.path.join("tables", "swabs-ra-summary.tsv"), "w") as outf:
     writer = csv.writer(outf, delimiter="\t")
-    writer.writerow(["date", "location", "species", "assignment", "non_dedup_hv", "dedup_hv", "all_reads"])
+    writer.writerow([
+        "date",
+        "location",
+        "assignment",
+        "species",
+        "group",
+        "non_dedup_hv",
+        "dedup_hv",
+        "all_reads"
+    ])
     # Sort samples by date
     sorted_samples = sorted(samples.items(), key=lambda x: x[0][0])
     for (date, location, pathogen), data in sorted_samples:
-        species = first_level_mapping[pathogen]
+        species = first_level_mapping(pathogen)
+        group = second_level_mapping(species)
         date_str = date.strftime("%y%m%d")
         writer.writerow([
             date_str,
             location,
-            species,
             pathogen,
+            species,
+            group,
             data.get("non_dedup", 0),
             data.get("dedup", 0),
             data["all_reads"],
@@ -172,8 +164,30 @@ with open(os.path.join("tables", "swabs-ra-summary.tsv"), "w") as outf:
 
 with open(os.path.join("tables", "swabs-ra-per-treatment-summary.tsv"), "w") as outf:
     writer = csv.writer(outf, delimiter="\t")
-    writer.writerow(["date", "location", "species", "pathogen", "treatment", "non_dedup", "dedup", "all_reads"])
-    for (date, location, pathogen, treatment), data in sorted(treatment_samples.items()):
-        species = first_level_mapping[pathogen]
+    writer.writerow([
+        "date",
+        "location",
+        "assignment",
+        "species",
+        "group",
+        "treatment",
+        "non_dedup",
+        "dedup",
+        "all_reads"
+    ])
+    # Sort samples by date
+    sorted_samples = sorted(treatment_samples.items(), key=lambda x: x[0][0])
+
+    for (date, location, pathogen, treatment), data in sorted_samples:
+        species = first_level_mapping(pathogen)
+        group = second_level_mapping(species)
         date_str = date.strftime("%y%m%d")
-        writer.writerow([date_str, location, species, pathogen, treatment, data.get("non_dedup", 0), data.get("dedup", 0), data["all_reads"]])
+        writer.writerow([
+            date_str,
+            location,
+            pathogen,
+            species,
+            group,
+            treatment,
+            data.get("non_dedup", 0),
+            data.get("dedup", 0),data["all_reads"]])

--- a/tables/swabs-ra-per-treatment-summary.tsv
+++ b/tables/swabs-ra-per-treatment-summary.tsv
@@ -1,49 +1,49 @@
-date	location	species	pathogen	treatment	non_dedup	dedup	all_reads
-250107	BoDT	Rhinovirus C	Rhinovirus C56	Filtration, CP, Zymo, Polyadenylated	12	12	328894
-250109	BoDT	RSV-B	RSVB	Filtration, CP, Qiagen, Polyadenylated	2	2	542383
-250113	BoDT	HCoV-OC43	Human coronavirus OC43	Filtration, Qiagen	4	3	1637488
-250113	BoDT	Rhinovirus A	Rhinovirus A94	Filtration, CP, Qiagen, Polyadenylated	1	1	542383
-250113	BoDT	Rhinovirus A	Rhinovirus A94	Filtration, Qiagen	6	5	1637488
-250115	BoDT	HCoV-NL63	Human coronavirus NL63	Filtration, Qiagen	19	14	1637488
-250116	BoDT	HCoV-NL63	Human coronavirus NL63	Filtration, Amicon, Qiagen	12	9	842301
-250116	BoDT	HCoV-NL63	Human coronavirus NL63	Filtration, Qiagen	1	1	1637488
-250116	BoDT	HCoV-OC43	Human coronavirus OC43	Filtration, Qiagen	1	1	1637488
-250116	BoDT	RSV-A	RSVA	Filtration, Amicon, Qiagen	10	10	842301
-250116	BoDT	RSV-A	RSVA	Filtration, Qiagen	1	0	1637488
-250123	BoDT	HCoV-HKU1	Human coronavirus HKU1	Filtration, Amicon, Qiagen	1	1	842301
-250123	BoDT	HCoV-HKU1	Human coronavirus HKU1	Filtration, Qiagen	130	74	1637488
-250123	BoDT	HCoV-NL63	Human coronavirus NL63	Filtration, Qiagen	2	2	1637488
-250123	BoDT	Rhinovirus C	Rhinovirus C42	Filtration, Amicon, Qiagen	3	3	842301
-250123	BoDT	Rhinovirus C	Rhinovirus C42	Filtration, Qiagen	5	4	1637488
-250127	BoDT	HPIV4b	HPIV4	Filtration, CP, Qiagen | cDNA input: = 1009.6 ng	1	1	395488
-250127	BoDT	HPIV4b	HPIV4	Filtration, CP, Qiagen | cDNA input: = 44.17 ng	1	1	131889
-250127	BoDT	HPIV4b	HPIV4	Filtration, Qiagen | cDNA input: = 44.64 ng	1	1	161683
-250127	BoDT	HCoV-OC43	Human coronavirus OC43	Filtration, CP, Qiagen	5	5	128548
-250127	BoDT	HCoV-OC43	Human coronavirus OC43	Filtration, CP, Qiagen | cDNA input: = 1009.6 ng	2	2	395488
-250127	BoDT	HCoV-OC43	Human coronavirus OC43	Filtration, Qiagen | cDNA input: = 44.64 ng	1	1	161683
-250127	BoDT	Rhinovirus A	Rhinovirus A34	Filtration, CP, Qiagen	2	2	128548
-250127	BoDT	Rhinovirus A	Rhinovirus A34	Filtration, CP, Qiagen | cDNA input: = 1009.6 ng	5	5	395488
-250127	BoDT	Rhinovirus B	Rhinovirus B37	Filtration, CP, Qiagen	2	2	128548
-250127	BoDT	Rhinovirus B	Rhinovirus B37	Filtration, CP, Qiagen | cDNA input: = 1009.6 ng	19	18	395488
-250127	BoDT	Rhinovirus B	Rhinovirus B37	Filtration, CP, Qiagen | cDNA input: = 44.17 ng	3	3	131889
-250127	BoDT	Rhinovirus B	Rhinovirus B37	Filtration, Qiagen | cDNA input: = 44.64 ng	4	4	161683
-250129	BoDT	HCoV-229E	Human coronavirus 229E	Filtration, CP, Qiagen | cDNA input: = 30.6 ng	1820	1215	351910
-250129	BoDT	HCoV-229E	Human coronavirus 229E	Filtration, CP, Qiagen | cDNA input: = 816 ng	1636	1530	287006
-250129	BoDT	HCoV-229E	Human coronavirus 229E	Filtration, Qiagen | cDNA input: = < 32 ng	3696	3215	736242
-250129	BoDT	HCoV-NL63	Human coronavirus NL63	Filtration, Qiagen | cDNA input: = < 32 ng	3	3	736242
-250129	BoDT	HCoV-OC43	Human coronavirus OC43	Filtration, CP, Qiagen | cDNA input: = 30.6 ng	52	34	351910
-250129	BoDT	HCoV-OC43	Human coronavirus OC43	Filtration, CP, Qiagen | cDNA input: = 816 ng	43	39	287006
-250129	BoDT	HCoV-OC43	Human coronavirus OC43	Filtration, Qiagen | cDNA input: = < 32 ng	96	88	736242
-250129	BoDT	Rhinovirus C	Rhinovirus C36	Filtration, CP, Qiagen | cDNA input: = 30.6 ng	4	4	351910
-250129	BoDT	Rhinovirus C	Rhinovirus C36	Filtration, CP, Qiagen | cDNA input: = 816 ng	43	39	287006
-250129	BoDT	Rhinovirus C	Rhinovirus C36	Filtration, Qiagen | cDNA input: = < 32 ng	41	36	736242
-250129	BoDT	Rhinovirus C	Rhinovirus C42	Filtration, CP, Qiagen | cDNA input: = 816 ng	1	1	287006
-250204	BoDT	HCoV-OC43	Human coronavirus OC43	Filtration, CP, Qiagen | cDNA input: = 771.2 ng	3	3	283834
-250204	BoDT	Rhinovirus C	Rhinovirus C2	Filtration, CP, Qiagen | cDNA input: = 33.74 ng	3	3	240475
-250204	BoDT	Rhinovirus C	Rhinovirus C2	Filtration, CP, Qiagen | cDNA input: = 771.2 ng	7	7	283834
-250204	BoDT	Rhinovirus C	Rhinovirus C2	Filtration, Qiagen | cDNA input: = < 32 ng	1	1	736242
-250204	BoDT	SARS-CoV-2	Severe acute respiratory syndrome coronavirus 2	Filtration, CP, Qiagen | cDNA input: = 33.74 ng	25	21	240475
-250204	BoDT	SARS-CoV-2	Severe acute respiratory syndrome coronavirus 2	Filtration, CP, Qiagen | cDNA input: = 771.2 ng	43	43	283834
-250204	BoDT	SARS-CoV-2	Severe acute respiratory syndrome coronavirus 2	Filtration, Qiagen | cDNA input: = < 32 ng	14	14	736242
-250205	BoDT	Rhinovirus A	Rhinovirus A34	Filtration, CP, Qiagen | DNAse	1	1	439325
-250212	BoDT	Influenza A	H1N1	Filtration, CP, Qiagen | DNAse	1	1	439325
+date	location	assignment	species	group	treatment	non_dedup	dedup	all_reads
+250107	BoDT	Rhinovirus C56	Rhinovirus C	Rhinoviruses	Filtration, CP, Zymo, Polyadenylated	12	12	328894
+250109	BoDT	RSVB	RSV-B	Mononegavirales	Filtration, CP, Qiagen, Polyadenylated	2	2	243294
+250113	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, Qiagen	4	3	108589
+250113	BoDT	Rhinovirus A94	Rhinovirus A	Rhinoviruses	Filtration, CP, Qiagen, Polyadenylated	1	1	299089
+250113	BoDT	Rhinovirus A94	Rhinovirus A	Rhinoviruses	Filtration, Qiagen	6	5	108589
+250115	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	Filtration, Qiagen	19	14	708774
+250116	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, Qiagen	1	1	40750
+250116	BoDT	RSVA	RSV-A	Mononegavirales	Filtration, Amicon, Qiagen	10	10	185349
+250116	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	Filtration, Amicon, Qiagen	12	9	185349
+250116	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	Filtration, Qiagen	1	1	40750
+250116	BoDT	RSVA	RSV-A	Mononegavirales	Filtration, Qiagen	1	0	40750
+250123	BoDT	Human coronavirus HKU1	HCoV-HKU1	Coronaviruses (seasonal)	Filtration, Qiagen	130	74	439809
+250123	BoDT	Human coronavirus HKU1	HCoV-HKU1	Coronaviruses (seasonal)	Filtration, Amicon, Qiagen	1	1	313957
+250123	BoDT	Rhinovirus C42	Rhinovirus C	Rhinoviruses	Filtration, Qiagen	5	4	439809
+250123	BoDT	Rhinovirus C42	Rhinovirus C	Rhinoviruses	Filtration, Amicon, Qiagen	3	3	313957
+250123	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	Filtration, Qiagen	2	2	439809
+250127	BoDT	HPIV4	HPIV4	Mononegavirales	Filtration, CP, Qiagen | cDNA input: = 44.17 ng	1	1	131889
+250127	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, CP, Qiagen | cDNA input: = 1009.6 ng	2	2	395488
+250127	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, Qiagen | cDNA input: = 44.64 ng	1	1	161683
+250127	BoDT	Rhinovirus B37	Rhinovirus B	Rhinoviruses	Filtration, CP, Qiagen | cDNA input: = 1009.6 ng	19	18	395488
+250127	BoDT	Rhinovirus B37	Rhinovirus B	Rhinoviruses	Filtration, Qiagen | cDNA input: = 44.64 ng	4	4	161683
+250127	BoDT	Rhinovirus B37	Rhinovirus B	Rhinoviruses	Filtration, CP, Qiagen | cDNA input: = 44.17 ng	3	3	131889
+250127	BoDT	Rhinovirus A34	Rhinovirus A	Rhinoviruses	Filtration, CP, Qiagen | cDNA input: = 1009.6 ng	5	5	395488
+250127	BoDT	HPIV4	HPIV4	Mononegavirales	Filtration, CP, Qiagen | cDNA input: = 1009.6 ng	1	1	395488
+250127	BoDT	HPIV4	HPIV4	Mononegavirales	Filtration, Qiagen | cDNA input: = 44.64 ng	1	1	161683
+250127	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, CP, Qiagen	5	5	128548
+250127	BoDT	Rhinovirus B37	Rhinovirus B	Rhinoviruses	Filtration, CP, Qiagen	2	2	128548
+250127	BoDT	Rhinovirus A34	Rhinovirus A	Rhinoviruses	Filtration, CP, Qiagen	2	2	128548
+250129	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, CP, Qiagen | cDNA input: = 30.6 ng	52	34	351910
+250129	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, Qiagen | cDNA input: = < 32 ng	96	88	599313
+250129	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, CP, Qiagen | cDNA input: = 816 ng	43	39	287006
+250129	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	Filtration, Qiagen | cDNA input: = < 32 ng	3	3	599313
+250129	BoDT	Rhinovirus C42	Rhinovirus C	Rhinoviruses	Filtration, CP, Qiagen | cDNA input: = 816 ng	1	1	287006
+250129	BoDT	Rhinovirus C36	Rhinovirus C	Rhinoviruses	Filtration, Qiagen | cDNA input: = < 32 ng	41	36	599313
+250129	BoDT	Rhinovirus C36	Rhinovirus C	Rhinoviruses	Filtration, CP, Qiagen | cDNA input: = 816 ng	43	39	287006
+250129	BoDT	Rhinovirus C36	Rhinovirus C	Rhinoviruses	Filtration, CP, Qiagen | cDNA input: = 30.6 ng	4	4	351910
+250129	BoDT	Human coronavirus 229E	HCoV-229E	Coronaviruses (seasonal)	Filtration, Qiagen | cDNA input: = < 32 ng	3696	3215	599313
+250129	BoDT	Human coronavirus 229E	HCoV-229E	Coronaviruses (seasonal)	Filtration, CP, Qiagen | cDNA input: = 816 ng	1636	1530	287006
+250129	BoDT	Human coronavirus 229E	HCoV-229E	Coronaviruses (seasonal)	Filtration, CP, Qiagen | cDNA input: = 30.6 ng	1820	1215	351910
+250204	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, CP, Qiagen | cDNA input: = 771.2 ng	3	3	283834
+250204	BoDT	Rhinovirus C2	Rhinovirus C	Rhinoviruses	Filtration, CP, Qiagen | cDNA input: = 771.2 ng	7	7	283834
+250204	BoDT	Rhinovirus C2	Rhinovirus C	Rhinoviruses	Filtration, CP, Qiagen | cDNA input: = 33.74 ng	3	3	240475
+250204	BoDT	Rhinovirus C2	Rhinovirus C	Rhinoviruses	Filtration, Qiagen | cDNA input: = < 32 ng	1	1	136929
+250204	BoDT	Severe acute respiratory syndrome coronavirus 2	SARS-CoV-2	Coronaviruses (SARS-CoV-2)	Filtration, CP, Qiagen | cDNA input: = 771.2 ng	43	43	283834
+250204	BoDT	Severe acute respiratory syndrome coronavirus 2	SARS-CoV-2	Coronaviruses (SARS-CoV-2)	Filtration, CP, Qiagen | cDNA input: = 33.74 ng	25	21	240475
+250204	BoDT	Severe acute respiratory syndrome coronavirus 2	SARS-CoV-2	Coronaviruses (SARS-CoV-2)	Filtration, Qiagen | cDNA input: = < 32 ng	14	14	136929
+250205	BoDT	Rhinovirus A34	Rhinovirus A	Rhinoviruses	Filtration, CP, Qiagen | DNAse	1	1	149289
+250212	BoDT	H1N1	H1N1	Influenza	Filtration, CP, Qiagen | DNAse	1	1	202226

--- a/tables/swabs-ra-summary.tsv
+++ b/tables/swabs-ra-summary.tsv
@@ -1,26 +1,26 @@
-date	location	species	assignment	non_dedup_hv	dedup_hv	all_reads
-250107	BoDT	Rhinovirus C	Rhinovirus C56	12	12	328894
-250109	BoDT	RSV-B	RSVB	2	2	243294
-250113	BoDT	HCoV-OC43	Human coronavirus OC43	4	3	407678
-250113	BoDT	Rhinovirus A	Rhinovirus A94	7	6	407678
-250115	BoDT	HCoV-NL63	Human coronavirus NL63	19	14	857131
-250116	BoDT	HCoV-OC43	Human coronavirus OC43	1	1	226099
-250116	BoDT	RSV-A	RSVA	11	10	226099
-250116	BoDT	HCoV-NL63	Human coronavirus NL63	13	10	226099
-250123	BoDT	HCoV-HKU1	Human coronavirus HKU1	131	75	753766
-250123	BoDT	Rhinovirus C	Rhinovirus C42	8	7	753766
-250123	BoDT	HCoV-NL63	Human coronavirus NL63	2	2	753766
-250127	BoDT	HPIV4b	HPIV4	3	3	817608
-250127	BoDT	HCoV-OC43	Human coronavirus OC43	8	8	817608
-250127	BoDT	Rhinovirus B	Rhinovirus B37	28	27	817608
-250127	BoDT	Rhinovirus A	Rhinovirus A34	7	7	817608
-250129	BoDT	HCoV-OC43	Human coronavirus OC43	191	161	1238229
-250129	BoDT	HCoV-NL63	Human coronavirus NL63	3	3	1238229
-250129	BoDT	Rhinovirus C	Rhinovirus C42	1	1	1238229
-250129	BoDT	Rhinovirus C	Rhinovirus C36	88	79	1238229
-250129	BoDT	HCoV-229E	Human coronavirus 229E	7152	5960	1238229
-250204	BoDT	HCoV-OC43	Human coronavirus OC43	3	3	661238
-250204	BoDT	Rhinovirus C	Rhinovirus C2	11	11	661238
-250204	BoDT	SARS-CoV-2	Severe acute respiratory syndrome coronavirus 2	82	78	661238
-250205	BoDT	Rhinovirus A	Rhinovirus A34	1	1	175859
-250212	BoDT	Influenza A	H1N1	1	1	216826
+date	location	assignment	species	group	non_dedup_hv	dedup_hv	all_reads
+250107	BoDT	Rhinovirus C56	Rhinovirus C	Rhinoviruses	12	12	328894
+250109	BoDT	RSVB	RSV-B	Mononegavirales	2	2	243294
+250113	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	4	3	407678
+250113	BoDT	Rhinovirus A94	Rhinovirus A	Rhinoviruses	7	6	407678
+250115	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	19	14	857131
+250116	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	1	1	226099
+250116	BoDT	RSVA	RSV-A	Mononegavirales	11	10	226099
+250116	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	13	10	226099
+250123	BoDT	Human coronavirus HKU1	HCoV-HKU1	Coronaviruses (seasonal)	131	75	753766
+250123	BoDT	Rhinovirus C42	Rhinovirus C	Rhinoviruses	8	7	753766
+250123	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	2	2	753766
+250127	BoDT	HPIV4	HPIV4	Mononegavirales	3	3	817608
+250127	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	8	8	817608
+250127	BoDT	Rhinovirus B37	Rhinovirus B	Rhinoviruses	28	27	817608
+250127	BoDT	Rhinovirus A34	Rhinovirus A	Rhinoviruses	7	7	817608
+250129	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	191	161	1238229
+250129	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	3	3	1238229
+250129	BoDT	Rhinovirus C42	Rhinovirus C	Rhinoviruses	1	1	1238229
+250129	BoDT	Rhinovirus C36	Rhinovirus C	Rhinoviruses	88	79	1238229
+250129	BoDT	Human coronavirus 229E	HCoV-229E	Coronaviruses (seasonal)	7152	5960	1238229
+250204	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	3	3	661238
+250204	BoDT	Rhinovirus C2	Rhinovirus C	Rhinoviruses	11	11	661238
+250204	BoDT	Severe acute respiratory syndrome coronavirus 2	SARS-CoV-2	Coronaviruses (SARS-CoV-2)	82	78	661238
+250205	BoDT	Rhinovirus A34	Rhinovirus A	Rhinoviruses	1	1	175859
+250212	BoDT	H1N1	H1N1	Influenza	1	1	216826

--- a/ww-genomes.json
+++ b/ww-genomes.json
@@ -102,6 +102,7 @@
 
     "MN901833.1": "Human mastadenovirus A",
     "PQ189755.1": "Human mastadenovirus B114",
+    "LC791177.1": "Human mastadenovirus F",
     "OR876398.1": "Human adenovirus 5",
 
     "NC_076019.1": "Apodemus agrarius picornavirus strain Longwan-Rn37 polyprotein"


### PR DESCRIPTION
Add metadata utility functions and swab RA processing script
- Introduced `metadata_utils.py` for mapping pathogen names and filtering pathogens to ignore.
- Updated `swab-ra-tables.py` to include clearer assignment and group information. Fixed total read counts for treatments.