### PR TITLE
Fixing dedup HV counts for both swabs and wastewater

### DIFF
--- a/scripts/swab-ra-tables.py
+++ b/scripts/swab-ra-tables.py
@@ -86,8 +86,6 @@ with open(os.path.join(validation_output_dir, "swabs-classified-all-reads.tsv"))
         # Only count non-duplicate reads for deduplicated count
         if duplicate == "False":
             samples[(date, location, pathogen)]["dedup"] += 1
-            samples[(date, location, pathogen)]["non_dedup"] += 1
-            treatment_samples[(date, location, pathogen, treatment)]["non_dedup"] += 1
             treatment_samples[(date, location, pathogen, treatment)]["dedup"] += 1
 
 # Process non-validated reads

--- a/tables/swabs-ra-per-treatment-summary.tsv
+++ b/tables/swabs-ra-per-treatment-summary.tsv
@@ -1,50 +1,50 @@
 date	location	assignment	species	group	treatment	non_dedup	dedup	all_reads
-250107	BoDT	Rhinovirus C56	Rhinovirus C	Rhinoviruses	Filtration, CP, Zymo, Polyadenylated	29	14	328894
-250109	BoDT	RSVB	RSV-B	Mononegavirales	Filtration, CP, Qiagen, Polyadenylated	2	1	243294
-250113	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, Qiagen	7	3	108589
-250113	BoDT	Rhinovirus A94	Rhinovirus A	Rhinoviruses	Filtration, CP, Qiagen, Polyadenylated	2	1	299089
-250113	BoDT	Rhinovirus A94	Rhinovirus A	Rhinoviruses	Filtration, Qiagen	9	4	108589
-250115	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	Filtration, Qiagen	24	12	708774
-250116	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	Filtration, Amicon, Qiagen	12	6	185349
-250116	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	Filtration, Qiagen	2	1	40750
-250116	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, Qiagen	2	1	40750
-250116	BoDT	RSVA	RSV-A	Mononegavirales	Filtration, Amicon, Qiagen	14	7	185349
+250107	BoDT	Rhinovirus C56	Rhinovirus C	Rhinoviruses	Filtration, CP, Zymo, Polyadenylated	15	14	328894
+250109	BoDT	RSVB	RSV-B	Mononegavirales	Filtration, CP, Qiagen, Polyadenylated	1	1	243294
+250113	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, Qiagen	4	3	108589
+250113	BoDT	Rhinovirus A94	Rhinovirus A	Rhinoviruses	Filtration, CP, Qiagen, Polyadenylated	1	1	299089
+250113	BoDT	Rhinovirus A94	Rhinovirus A	Rhinoviruses	Filtration, Qiagen	5	4	108589
+250115	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	Filtration, Qiagen	12	12	708774
+250116	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	Filtration, Amicon, Qiagen	6	6	185349
+250116	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	Filtration, Qiagen	1	1	40750
+250116	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, Qiagen	1	1	40750
+250116	BoDT	RSVA	RSV-A	Mononegavirales	Filtration, Amicon, Qiagen	7	7	185349
 250116	BoDT	RSVA	RSV-A	Mononegavirales	Filtration, Qiagen	1	0	40750
-250116	BoDT	Rhinovirus B101	Rhinovirus B	Rhinoviruses	Filtration, Amicon, Qiagen	2	1	185349
-250123	BoDT	Human coronavirus HKU1	HCoV-HKU1	Coronaviruses (seasonal)	Filtration, Amicon, Qiagen	2	1	313957
-250123	BoDT	Human coronavirus HKU1	HCoV-HKU1	Coronaviruses (seasonal)	Filtration, Qiagen	48	24	439809
-250123	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	Filtration, Qiagen	2	1	439809
-250123	BoDT	Rhinovirus C42	Rhinovirus C	Rhinoviruses	Filtration, Amicon, Qiagen	4	2	313957
-250123	BoDT	Rhinovirus C42	Rhinovirus C	Rhinoviruses	Filtration, Qiagen	9	4	439809
-250127	BoDT	HPIV4	HPIV4	Mononegavirales	Filtration, CP, Qiagen | cDNA input: = 1009.6 ng	2	1	395488
-250127	BoDT	HPIV4	HPIV4	Mononegavirales	Filtration, CP, Qiagen | cDNA input: = 44.17 ng	2	1	131889
-250127	BoDT	HPIV4	HPIV4	Mononegavirales	Filtration, Qiagen | cDNA input: = 44.64 ng	2	1	161683
-250127	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, CP, Qiagen	4	2	128548
-250127	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, CP, Qiagen | cDNA input: = 1009.6 ng	4	2	395488
-250127	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, Qiagen | cDNA input: = 44.64 ng	2	1	161683
-250127	BoDT	Rhinovirus A34	Rhinovirus A	Rhinoviruses	Filtration, CP, Qiagen	2	1	128548
-250127	BoDT	Rhinovirus A34	Rhinovirus A	Rhinoviruses	Filtration, CP, Qiagen | cDNA input: = 1009.6 ng	4	2	395488
-250127	BoDT	Rhinovirus B37	Rhinovirus B	Rhinoviruses	Filtration, CP, Qiagen	2	1	128548
-250127	BoDT	Rhinovirus B37	Rhinovirus B	Rhinoviruses	Filtration, CP, Qiagen | cDNA input: = 1009.6 ng	29	14	395488
-250127	BoDT	Rhinovirus B37	Rhinovirus B	Rhinoviruses	Filtration, CP, Qiagen | cDNA input: = 44.17 ng	4	2	131889
-250127	BoDT	Rhinovirus B37	Rhinovirus B	Rhinoviruses	Filtration, Qiagen | cDNA input: = 44.64 ng	4	2	161683
-250129	BoDT	Human coronavirus 229E	HCoV-229E	Coronaviruses (seasonal)	Filtration, CP, Qiagen | cDNA input: = 30.6 ng	1831	1232	351910
+250116	BoDT	Rhinovirus B101	Rhinovirus B	Rhinoviruses	Filtration, Amicon, Qiagen	1	1	185349
+250123	BoDT	Human coronavirus HKU1	HCoV-HKU1	Coronaviruses (seasonal)	Filtration, Amicon, Qiagen	1	1	313957
+250123	BoDT	Human coronavirus HKU1	HCoV-HKU1	Coronaviruses (seasonal)	Filtration, Qiagen	24	24	439809
+250123	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	Filtration, Qiagen	1	1	439809
+250123	BoDT	Rhinovirus C42	Rhinovirus C	Rhinoviruses	Filtration, Amicon, Qiagen	2	2	313957
+250123	BoDT	Rhinovirus C42	Rhinovirus C	Rhinoviruses	Filtration, Qiagen	5	4	439809
+250127	BoDT	HPIV4	HPIV4	Mononegavirales	Filtration, CP, Qiagen | cDNA input: = 1009.6 ng	1	1	395488
+250127	BoDT	HPIV4	HPIV4	Mononegavirales	Filtration, CP, Qiagen | cDNA input: = 44.17 ng	1	1	131889
+250127	BoDT	HPIV4	HPIV4	Mononegavirales	Filtration, Qiagen | cDNA input: = 44.64 ng	1	1	161683
+250127	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, CP, Qiagen	2	2	128548
+250127	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, CP, Qiagen | cDNA input: = 1009.6 ng	2	2	395488
+250127	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, Qiagen | cDNA input: = 44.64 ng	1	1	161683
+250127	BoDT	Rhinovirus A34	Rhinovirus A	Rhinoviruses	Filtration, CP, Qiagen	1	1	128548
+250127	BoDT	Rhinovirus A34	Rhinovirus A	Rhinoviruses	Filtration, CP, Qiagen | cDNA input: = 1009.6 ng	2	2	395488
+250127	BoDT	Rhinovirus B37	Rhinovirus B	Rhinoviruses	Filtration, CP, Qiagen	1	1	128548
+250127	BoDT	Rhinovirus B37	Rhinovirus B	Rhinoviruses	Filtration, CP, Qiagen | cDNA input: = 1009.6 ng	15	14	395488
+250127	BoDT	Rhinovirus B37	Rhinovirus B	Rhinoviruses	Filtration, CP, Qiagen | cDNA input: = 44.17 ng	2	2	131889
+250127	BoDT	Rhinovirus B37	Rhinovirus B	Rhinoviruses	Filtration, Qiagen | cDNA input: = 44.64 ng	2	2	161683
+250129	BoDT	Human coronavirus 229E	HCoV-229E	Coronaviruses (seasonal)	Filtration, CP, Qiagen | cDNA input: = 30.6 ng	1830	1232	351910
 250129	BoDT	Human coronavirus 229E	HCoV-229E	Coronaviruses (seasonal)	Filtration, CP, Qiagen | cDNA input: = 816 ng	1643	1534	287006
-250129	BoDT	Human coronavirus 229E	HCoV-229E	Coronaviruses (seasonal)	Filtration, Qiagen | cDNA input: = < 32 ng	3749	3242	599313
-250129	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	Filtration, Qiagen | cDNA input: = < 32 ng	4	2	599313
-250129	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, CP, Qiagen | cDNA input: = 30.6 ng	76	30	351910
-250129	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, CP, Qiagen | cDNA input: = 816 ng	75	36	287006
-250129	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, Qiagen | cDNA input: = < 32 ng	172	82	599313
-250129	BoDT	Rhinovirus C36	Rhinovirus C	Rhinoviruses	Filtration, CP, Qiagen | cDNA input: = 30.6 ng	8	4	351910
-250129	BoDT	Rhinovirus C36	Rhinovirus C	Rhinoviruses	Filtration, CP, Qiagen | cDNA input: = 816 ng	70	34	287006
-250129	BoDT	Rhinovirus C36	Rhinovirus C	Rhinoviruses	Filtration, Qiagen | cDNA input: = < 32 ng	72	33	599313
-250129	BoDT	Rhinovirus C42	Rhinovirus C	Rhinoviruses	Filtration, CP, Qiagen | cDNA input: = 816 ng	2	1	287006
-250204	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, CP, Qiagen | cDNA input: = 771.2 ng	6	3	283834
-250204	BoDT	Rhinovirus C2	Rhinovirus C	Rhinoviruses	Filtration, CP, Qiagen | cDNA input: = 33.74 ng	4	2	240475
-250204	BoDT	Rhinovirus C2	Rhinovirus C	Rhinoviruses	Filtration, CP, Qiagen | cDNA input: = 771.2 ng	10	5	283834
-250204	BoDT	Rhinovirus C2	Rhinovirus C	Rhinoviruses	Filtration, Qiagen | cDNA input: = < 32 ng	2	1	136929
+250129	BoDT	Human coronavirus 229E	HCoV-229E	Coronaviruses (seasonal)	Filtration, Qiagen | cDNA input: = < 32 ng	3746	3242	599313
+250129	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	Filtration, Qiagen | cDNA input: = < 32 ng	2	2	599313
+250129	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, CP, Qiagen | cDNA input: = 30.6 ng	46	30	351910
+250129	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, CP, Qiagen | cDNA input: = 816 ng	39	36	287006
+250129	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, Qiagen | cDNA input: = < 32 ng	90	82	599313
+250129	BoDT	Rhinovirus C36	Rhinovirus C	Rhinoviruses	Filtration, CP, Qiagen | cDNA input: = 30.6 ng	4	4	351910
+250129	BoDT	Rhinovirus C36	Rhinovirus C	Rhinoviruses	Filtration, CP, Qiagen | cDNA input: = 816 ng	36	34	287006
+250129	BoDT	Rhinovirus C36	Rhinovirus C	Rhinoviruses	Filtration, Qiagen | cDNA input: = < 32 ng	39	33	599313
+250129	BoDT	Rhinovirus C42	Rhinovirus C	Rhinoviruses	Filtration, CP, Qiagen | cDNA input: = 816 ng	1	1	287006
+250204	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	Filtration, CP, Qiagen | cDNA input: = 771.2 ng	3	3	283834
+250204	BoDT	Rhinovirus C2	Rhinovirus C	Rhinoviruses	Filtration, CP, Qiagen | cDNA input: = 33.74 ng	2	2	240475
+250204	BoDT	Rhinovirus C2	Rhinovirus C	Rhinoviruses	Filtration, CP, Qiagen | cDNA input: = 771.2 ng	5	5	283834
+250204	BoDT	Rhinovirus C2	Rhinovirus C	Rhinoviruses	Filtration, Qiagen | cDNA input: = < 32 ng	1	1	136929
 250204	BoDT	Severe acute respiratory syndrome coronavirus 2	SARS-CoV-2	Coronaviruses (SARS-CoV-2)	Filtration, CP, Qiagen | cDNA input: = 33.74 ng	25	21	240475
 250204	BoDT	Severe acute respiratory syndrome coronavirus 2	SARS-CoV-2	Coronaviruses (SARS-CoV-2)	Filtration, CP, Qiagen | cDNA input: = 771.2 ng	43	43	283834
 250204	BoDT	Severe acute respiratory syndrome coronavirus 2	SARS-CoV-2	Coronaviruses (SARS-CoV-2)	Filtration, Qiagen | cDNA input: = < 32 ng	14	14	136929
-250205	BoDT	Rhinovirus A34	Rhinovirus A	Rhinoviruses	Filtration, CP, Qiagen | DNAse	2	1	139820
-250212	BoDT	H1N1	H1N1	Influenza	Filtration, CP, Qiagen | DNAse	2	1	197085
+250205	BoDT	Rhinovirus A34	Rhinovirus A	Rhinoviruses	Filtration, CP, Qiagen | DNAse	1	1	139820
+250212	BoDT	H1N1	H1N1	Influenza	Filtration, CP, Qiagen | DNAse	1	1	197085

--- a/tables/swabs-ra-summary.tsv
+++ b/tables/swabs-ra-summary.tsv
@@ -1,27 +1,27 @@
 date	location	assignment	species	group	non_dedup_hv	dedup_hv	all_reads
-250107	BoDT	Rhinovirus C56	Rhinovirus C	Rhinoviruses	29	14	328894
-250109	BoDT	RSVB	RSV-B	Mononegavirales	2	1	243294
-250113	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	7	3	407678
-250113	BoDT	Rhinovirus A94	Rhinovirus A	Rhinoviruses	11	5	407678
-250115	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	24	12	857131
-250116	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	14	7	226099
-250116	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	2	1	226099
-250116	BoDT	RSVA	RSV-A	Mononegavirales	15	7	226099
-250116	BoDT	Rhinovirus B101	Rhinovirus B	Rhinoviruses	2	1	226099
-250123	BoDT	Human coronavirus HKU1	HCoV-HKU1	Coronaviruses (seasonal)	50	25	753766
-250123	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	2	1	753766
-250123	BoDT	Rhinovirus C42	Rhinovirus C	Rhinoviruses	13	6	753766
-250127	BoDT	HPIV4	HPIV4	Mononegavirales	6	3	817608
-250127	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	10	5	817608
-250127	BoDT	Rhinovirus A34	Rhinovirus A	Rhinoviruses	6	3	817608
-250127	BoDT	Rhinovirus B37	Rhinovirus B	Rhinoviruses	39	19	817608
-250129	BoDT	Human coronavirus 229E	HCoV-229E	Coronaviruses (seasonal)	7223	6008	1238229
-250129	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	4	2	1238229
-250129	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	323	148	1238229
-250129	BoDT	Rhinovirus C36	Rhinovirus C	Rhinoviruses	150	71	1238229
-250129	BoDT	Rhinovirus C42	Rhinovirus C	Rhinoviruses	2	1	1238229
-250204	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	6	3	661238
-250204	BoDT	Rhinovirus C2	Rhinovirus C	Rhinoviruses	16	8	661238
+250107	BoDT	Rhinovirus C56	Rhinovirus C	Rhinoviruses	15	14	328894
+250109	BoDT	RSVB	RSV-B	Mononegavirales	1	1	243294
+250113	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	4	3	407678
+250113	BoDT	Rhinovirus A94	Rhinovirus A	Rhinoviruses	6	5	407678
+250115	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	12	12	857131
+250116	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	7	7	226099
+250116	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	1	1	226099
+250116	BoDT	RSVA	RSV-A	Mononegavirales	8	7	226099
+250116	BoDT	Rhinovirus B101	Rhinovirus B	Rhinoviruses	1	1	226099
+250123	BoDT	Human coronavirus HKU1	HCoV-HKU1	Coronaviruses (seasonal)	25	25	753766
+250123	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	1	1	753766
+250123	BoDT	Rhinovirus C42	Rhinovirus C	Rhinoviruses	7	6	753766
+250127	BoDT	HPIV4	HPIV4	Mononegavirales	3	3	817608
+250127	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	5	5	817608
+250127	BoDT	Rhinovirus A34	Rhinovirus A	Rhinoviruses	3	3	817608
+250127	BoDT	Rhinovirus B37	Rhinovirus B	Rhinoviruses	20	19	817608
+250129	BoDT	Human coronavirus 229E	HCoV-229E	Coronaviruses (seasonal)	7219	6008	1238229
+250129	BoDT	Human coronavirus NL63	HCoV-NL63	Coronaviruses (seasonal)	2	2	1238229
+250129	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	175	148	1238229
+250129	BoDT	Rhinovirus C36	Rhinovirus C	Rhinoviruses	79	71	1238229
+250129	BoDT	Rhinovirus C42	Rhinovirus C	Rhinoviruses	1	1	1238229
+250204	BoDT	Human coronavirus OC43	HCoV-OC43	Coronaviruses (seasonal)	3	3	661238
+250204	BoDT	Rhinovirus C2	Rhinovirus C	Rhinoviruses	8	8	661238
 250204	BoDT	Severe acute respiratory syndrome coronavirus 2	SARS-CoV-2	Coronaviruses (SARS-CoV-2)	82	78	661238
-250205	BoDT	Rhinovirus A34	Rhinovirus A	Rhinoviruses	2	1	165046
-250212	BoDT	H1N1	H1N1	Influenza	2	1	211685
+250205	BoDT	Rhinovirus A34	Rhinovirus A	Rhinoviruses	1	1	165046
+250212	BoDT	H1N1	H1N1	Influenza	1	1	211685


### PR DESCRIPTION
Fixing a counting error in ww-ra-tables.py that misallocated duplicate reads to non-duplicate counts.